### PR TITLE
ci: Make versioning of deployments more reliable

### DIFF
--- a/.github/workflows/sandbox_build_and_deploy.yml
+++ b/.github/workflows/sandbox_build_and_deploy.yml
@@ -11,13 +11,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Declare variables
         id: vars
         shell: bash
         run: |
-          echo "::set-output name=version::$(git describe --tags --always)"
+          echo "::set-output name=version::$(git rev-parse --short HEAD)"
 
       - name: Cache Docker layers
         uses: actions/cache@v2

--- a/.github/workflows/tag_build_and_deploy.yml
+++ b/.github/workflows/tag_build_and_deploy.yml
@@ -8,17 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Declare variables
-        id: vars
-        shell: bash
-        run: |
-          echo "::set-output name=version::$(git describe --tags --always)"
-
-      - name: Get tag
-        id: tag
-        uses: dawidd6/action-get-tag@v1
+      - uses: actions/checkout@v3
 
       - name: Cache Docker layers
         uses: actions/cache@v2
@@ -45,8 +35,8 @@ jobs:
           context: .
           file: Dockerfile
           push: true
-          build-args: VERSION= ${{ steps.vars.outputs.version }}
-          tags: membraneframework/demo_webrtc_videoroom_advanced:${{ steps.tag.outputs.tag }}
+          build-args: VERSION= ${{ github.ref_name }}
+          tags: membraneframework/demo_webrtc_videoroom_advanced:${{ github.ref_name }}
 
       - name: Build and push latest version 
         id: docker_build_latest
@@ -55,14 +45,14 @@ jobs:
           context: .
           file: Dockerfile
           push: true
-          build-args: VERSION= ${{ steps.vars.outputs.version }}
+          build-args: VERSION= ${{ github.ref_name }}
           tags: membraneframework/demo_webrtc_videoroom_advanced:latest
 
   deploy:
     runs-on: ubuntu-latest
     needs: build
     steps:  
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Deploy docker compose to a pre-configured server
         id: deploy


### PR DESCRIPTION
* For tag deploy uses a variable provided by `github` context
* For `sandbox` - since the checkout only fetches one commit without history, the result of `describe` would always be the commit's short sha - now it is done explicitly. As discussed, we didn't want to bring the whole repo history just to put the last tag in the version as well.

