### PR TITLE
Fix MV-126 (screensharing on mobile browsers)

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -47,3 +47,12 @@
   filter: invert(17%) sepia(81%) saturate(3321%) hue-rotate(352deg)
     brightness(96%) contrast(99%);
 }
+
+/**
+Don't display screensharing control on mobile browsers
+**/
+@media (max-width: 768px) { 
+  #screensharing-control {
+    display: none;
+  }
+ }


### PR DESCRIPTION
This PR add "display: none" property on screensharing control for mobile browsers. Screensharing on mobile browsers are not supported so this control shouldn't be visible.