### PR TITLE
Add instructions to set `EXTERNAL_IP` when starting without Docker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ npm ci --prefix=assets
 To run, type:
 
 ```
-mix phx.server 
+EXTERNAL_IP=<IPv4> mix phx.server 
 ```
+`EXTERNAL_IP` should be set to the local IP address of the computer this is running on.
 
 Then go to <http://localhost:4000/>.
 


### PR DESCRIPTION
Without setting the `EXTERNAL_IP` variable Firefox will not work when running Videoroom using `mix phx.start`, and the current README doesn't specify this should be done.