### PR TITLE
MV-233 Duplicated media section workaround

### DIFF
--- a/assets/src/pages/room/RoomPage.tsx
+++ b/assets/src/pages/room/RoomPage.tsx
@@ -103,17 +103,17 @@ const RoomPage: FC<Props> = ({ roomId, displayName, isSimulcastOn, manualMode, a
             webrtc={webrtc}
           />
         </section>
-        <MediaControlButtons
-          mode={mode}
-          userMediaVideo={camera.local}
-          cameraStreaming={camera.remote}
-          userMediaAudio={audio.local}
-          audioStreaming={audio.remote}
-          displayMedia={screenSharing.local}
-          screenSharingStreaming={screenSharing.remote}
-        />
       </div>
-      <div className="absolute bottom-2 left-1/2 -translate-x-1/2 md:right-2 md:-translate-x-1 md:left-auto flex flex-col items-stretch">
+      <MediaControlButtons
+        mode={mode}
+        userMediaVideo={camera.local}
+        cameraStreaming={camera.remote}
+        userMediaAudio={audio.local}
+        audioStreaming={audio.remote}
+        displayMedia={screenSharing.local}
+        screenSharingStreaming={screenSharing.remote}
+      />
+      <div className="absolute bottom-2 right-2 flex flex-col items-stretch">
         {isSimulcastOn && (
           <button
             onClick={toggleSimulcastMenu}

--- a/assets/src/pages/room/components/MediaControlButton.tsx
+++ b/assets/src/pages/room/components/MediaControlButton.tsx
@@ -16,10 +16,10 @@ const MediaControlButton: FC<MediaControlButtonProps> = ({
   return (
     <button
       onClick={onClick}
-      className="group relative flex justify-center items-center z-10 mr-2 p-3 rounded-full transition duration-300 ease-in-out border-2 border-white bg-white/0 hover:bg-white/40 disabled:bg-white/50 disabled:pointer-events-none"
+      className="group min-w-[52px] relative flex justify-center items-center z-10 m-1 p-3 rounded-full transition duration-300 ease-in-out border-2 border-white bg-white/0 hover:bg-white/40 disabled:bg-white/50 disabled:pointer-events-none"
     >
       <img
-        className={`invert group-disabled:invert-80 ${imgClasses}`}
+        className={`invert group-disabled:invert-80 ${imgClasses || ""}`}
         height="26"
         width="26"
         src={icon}

--- a/assets/src/pages/room/components/MediaControlButtons.tsx
+++ b/assets/src/pages/room/components/MediaControlButtons.tsx
@@ -4,14 +4,17 @@ import { UseMediaResult } from "../hooks/useMedia";
 import MediaControlButton, { MediaControlButtonProps } from "./MediaControlButton";
 import { NavigateFunction, useNavigate } from "react-router-dom";
 import { MembraneStreaming, StreamingMode } from "../hooks/useMembraneMediaStreaming";
+import { useToggle } from "../hooks/useToggle";
 
-const getControlsAutomatic = (
-  userMediaAudio: UseMediaResult,
-  audioStreaming: MembraneStreaming,
-  userMediaVideo: UseMediaResult,
-  cameraStreaming: MembraneStreaming,
-  displayMedia: UseMediaResult,
-  screenSharingStreaming: MembraneStreaming,
+const getAutomaticControls = (
+  {
+    userMediaAudio,
+    audioStreaming,
+    userMediaVideo,
+    cameraStreaming,
+    displayMedia,
+    screenSharingStreaming,
+  }: LocalUserMediaControls,
   navigate: NavigateFunction
 ): MediaControlButtonProps[] => [
   userMediaAudio.isEnabled
@@ -76,158 +79,171 @@ const getControlsAutomatic = (
 ];
 
 const getManualControls = (
-  userMediaAudio: UseMediaResult,
-  audioStreaming: MembraneStreaming,
-  userMediaVideo: UseMediaResult,
-  cameraStreaming: MembraneStreaming,
-  displayMedia: UseMediaResult,
-  screenSharingStreaming: MembraneStreaming,
-  navigate: NavigateFunction
-) => [
-  userMediaAudio.stream
-    ? {
-        icon: "/svg/mic-line.svg",
-        hover: "Start the microphone",
-        onClick: () => userMediaAudio.stop(),
-      }
-    : {
-        icon: "/svg/mic-off-fill.svg",
-        hover: "Stop the microphone",
-        onClick: () => userMediaAudio.start(),
-      },
-  userMediaAudio.isEnabled
-    ? {
-        icon: "/svg/mic-line.svg",
-        hover: "Disable microphone stream",
-        onClick: () => userMediaAudio.disable(),
-      }
-    : {
-        icon: "/svg/mic-off-fill.svg",
-        hover: "Enable microphone stream",
-        onClick: () => userMediaAudio.enable(),
-      },
-  audioStreaming.tracksId.length !== 0
-    ? {
-        icon: "/svg/mic-line.svg",
-        hover: "Remove microphone track",
-        onClick: () => audioStreaming.removeTracks(),
-      }
-    : {
-        icon: "/svg/mic-off-fill.svg",
-        hover: "Add microphone track",
-        onClick: () => userMediaAudio?.stream && audioStreaming.addTracks(userMediaAudio?.stream),
-      },
-  audioStreaming.trackMetadata?.active
-    ? {
-        icon: "/svg/mic-line.svg",
-        hover: "Set 'active' metadata to 'false'",
-        onClick: () => audioStreaming.setActive(false),
-      }
-    : {
-        icon: "/svg/mic-off-fill.svg",
-        hover: "Set 'active' metadata to 'true'",
-        onClick: () => audioStreaming.setActive(true),
-      },
-  userMediaVideo.stream
-    ? {
-        icon: "/svg/camera-line.svg",
-        hover: "Turn off the camera",
-        onClick: () => userMediaVideo.stop(),
-      }
-    : {
-        hover: "Turn on the camera",
-        icon: "/svg/camera-off-line.svg",
-        onClick: () => userMediaVideo.start(),
-      },
-  userMediaVideo.isEnabled
-    ? {
-        icon: "/svg/camera-line.svg",
-        hover: "Disable the camera stream",
-        onClick: () => userMediaVideo.disable(),
-      }
-    : {
-        hover: "Enable the the camera stream",
-        icon: "/svg/camera-off-line.svg",
-        onClick: () => userMediaVideo.enable(),
-      },
-  cameraStreaming.tracksId.length !== 0
-    ? {
-        icon: "/svg/camera-line.svg",
-        hover: "Remove camera track",
-        onClick: () => cameraStreaming.removeTracks(),
-      }
-    : {
-        icon: "/svg/camera-off-line.svg",
-        hover: "Add camera track",
-        onClick: () => userMediaVideo?.stream && cameraStreaming.addTracks(userMediaVideo?.stream),
-      },
-  cameraStreaming.trackMetadata?.active
-    ? {
-        icon: "/svg/camera-line.svg",
-        hover: "Set 'active' metadata to 'false'",
-        onClick: () => cameraStreaming.setActive(false),
-      }
-    : {
-        icon: "/svg/camera-off-line.svg",
-        hover: "Set 'active' metadata to 'true'",
-        onClick: () => cameraStreaming.setActive(true),
-      },
-  displayMedia.stream
-    ? {
-        icon: "/svg/computer-line.svg",
-        hover: "Stop the screensharing",
-        onClick: () => displayMedia.stop(),
-      }
-    : {
-        icon: "/svg/computer-line.svg",
-        hover: "Start the screensharing",
-        onClick: () => displayMedia.start(),
-      },
-  displayMedia.isEnabled
-    ? {
-        icon: "/svg/computer-line.svg",
-        hover: "Disable screensharing stream",
-        onClick: () => displayMedia.disable(),
-      }
-    : {
-        icon: "/svg/computer-line.svg",
-        hover: "Enable screensharing stream",
-        onClick: () => displayMedia.enable(),
-      },
-  screenSharingStreaming.tracksId.length !== 0
-    ? {
-        icon: "/svg/computer-line.svg",
-        hover: "Remove screensharing track",
-        onClick: () => screenSharingStreaming.removeTracks(),
-      }
-    : {
-        icon: "/svg/computer-line.svg",
-        hover: "Add screensharing track",
-        onClick: () => displayMedia?.stream && screenSharingStreaming.addTracks(displayMedia?.stream),
-      },
-  screenSharingStreaming.trackMetadata?.active
-    ? {
-        icon: "/svg/computer-line.svg",
-        hover: "Set 'active' metadata to 'false'",
-        onClick: () => screenSharingStreaming.setActive(false),
-      }
-    : {
-        icon: "/svg/computer-line.svg",
-        hover: "Set 'active' metadata to 'true'",
-        onClick: () => screenSharingStreaming.setActive(true),
-      },
   {
-    icon: "/svg/phone-fill.svg",
-    hover: "Leave the room",
-    imgClasses: "black-to-red transform rotate-135",
-    onClick: () => {
-      navigate("/");
+    userMediaAudio,
+    audioStreaming,
+    userMediaVideo,
+    cameraStreaming,
+    displayMedia,
+    screenSharingStreaming,
+  }: LocalUserMediaControls,
+  navigate: NavigateFunction
+): MediaControlButtonProps[][] => [
+  [
+    userMediaAudio.stream
+      ? {
+          icon: "/svg/mic-line.svg",
+          hover: "Start the microphone",
+          onClick: () => userMediaAudio.stop(),
+        }
+      : {
+          icon: "/svg/mic-off-fill.svg",
+          hover: "Stop the microphone",
+          onClick: () => userMediaAudio.start(),
+        },
+    userMediaAudio.isEnabled
+      ? {
+          icon: "/svg/mic-line.svg",
+          hover: "Disable microphone stream",
+          onClick: () => userMediaAudio.disable(),
+        }
+      : {
+          icon: "/svg/mic-off-fill.svg",
+          hover: "Enable microphone stream",
+          onClick: () => userMediaAudio.enable(),
+        },
+    audioStreaming.tracksId.length !== 0
+      ? {
+          icon: "/svg/mic-line.svg",
+          hover: "Remove microphone track",
+          onClick: () => audioStreaming.removeTracks(),
+        }
+      : {
+          icon: "/svg/mic-off-fill.svg",
+          hover: "Add microphone track",
+          onClick: () => userMediaAudio?.stream && audioStreaming.addTracks(userMediaAudio?.stream),
+        },
+    audioStreaming.trackMetadata?.active
+      ? {
+          icon: "/svg/mic-line.svg",
+          hover: "Set 'active' metadata to 'false'",
+          onClick: () => audioStreaming.setActive(false),
+        }
+      : {
+          icon: "/svg/mic-off-fill.svg",
+          hover: "Set 'active' metadata to 'true'",
+          onClick: () => audioStreaming.setActive(true),
+        },
+  ],
+  [
+    userMediaVideo.stream
+      ? {
+          icon: "/svg/camera-line.svg",
+          hover: "Turn off the camera",
+          onClick: () => userMediaVideo.stop(),
+        }
+      : {
+          hover: "Turn on the camera",
+          icon: "/svg/camera-off-line.svg",
+          onClick: () => userMediaVideo.start(),
+        },
+    userMediaVideo.isEnabled
+      ? {
+          icon: "/svg/camera-line.svg",
+          hover: "Disable the camera stream",
+          onClick: () => userMediaVideo.disable(),
+        }
+      : {
+          hover: "Enable the the camera stream",
+          icon: "/svg/camera-off-line.svg",
+          onClick: () => userMediaVideo.enable(),
+        },
+    cameraStreaming.tracksId.length !== 0
+      ? {
+          icon: "/svg/camera-line.svg",
+          hover: "Remove camera track",
+          onClick: () => cameraStreaming.removeTracks(),
+        }
+      : {
+          icon: "/svg/camera-off-line.svg",
+          hover: "Add camera track",
+          onClick: () => userMediaVideo?.stream && cameraStreaming.addTracks(userMediaVideo?.stream),
+        },
+    cameraStreaming.trackMetadata?.active
+      ? {
+          icon: "/svg/camera-line.svg",
+          hover: "Set 'active' metadata to 'false'",
+          onClick: () => cameraStreaming.setActive(false),
+        }
+      : {
+          icon: "/svg/camera-off-line.svg",
+          hover: "Set 'active' metadata to 'true'",
+          onClick: () => cameraStreaming.setActive(true),
+        },
+  ],
+  [
+    displayMedia.stream
+      ? {
+          icon: "/svg/computer-line.svg",
+          hover: "Stop the screensharing",
+          onClick: () => displayMedia.stop(),
+        }
+      : {
+          icon: "/svg/computer-line.svg",
+          hover: "Start the screensharing",
+          onClick: () => displayMedia.start(),
+        },
+    displayMedia.isEnabled
+      ? {
+          icon: "/svg/computer-line.svg",
+          hover: "Disable screensharing stream",
+          onClick: () => displayMedia.disable(),
+        }
+      : {
+          icon: "/svg/computer-line.svg",
+          hover: "Enable screensharing stream",
+          onClick: () => displayMedia.enable(),
+        },
+    screenSharingStreaming.tracksId.length !== 0
+      ? {
+          icon: "/svg/computer-line.svg",
+          hover: "Remove screensharing track",
+          onClick: () => screenSharingStreaming.removeTracks(),
+        }
+      : {
+          icon: "/svg/computer-line.svg",
+          hover: "Add screensharing track",
+          onClick: () => displayMedia?.stream && screenSharingStreaming.addTracks(displayMedia?.stream),
+        },
+    screenSharingStreaming.trackMetadata?.active
+      ? {
+          icon: "/svg/computer-line.svg",
+          hover: "Set 'active' metadata to 'false'",
+          onClick: () => screenSharingStreaming.setActive(false),
+        }
+      : {
+          icon: "/svg/computer-line.svg",
+          hover: "Set 'active' metadata to 'true'",
+          onClick: () => screenSharingStreaming.setActive(true),
+        },
+  ],
+  [
+    {
+      icon: "/svg/phone-fill.svg",
+      hover: "Leave the room",
+      imgClasses: "black-to-red transform rotate-135",
+      onClick: () => {
+        navigate("/");
+      },
     },
-  },
+  ],
 ];
 
 type Props = {
   mode: StreamingMode;
+} & LocalUserMediaControls;
+
+type LocalUserMediaControls = {
   userMediaVideo: UseMediaResult;
   cameraStreaming: MembraneStreaming;
   userMediaAudio: UseMediaResult;
@@ -236,45 +252,29 @@ type Props = {
   screenSharingStreaming: MembraneStreaming;
 };
 
-const MediaControlButtons: FC<Props> = ({
-  mode,
-  userMediaAudio,
-  audioStreaming,
-  userMediaVideo,
-  cameraStreaming,
-  displayMedia,
-  screenSharingStreaming,
-}: Props) => {
-  const navigate = useNavigate();
-  const controls: MediaControlButtonProps[] =
-    mode === "manual"
-      ? getManualControls(
-          userMediaAudio,
-          audioStreaming,
-          userMediaVideo,
-          cameraStreaming,
-          displayMedia,
-          screenSharingStreaming,
-          navigate
-        )
-      : getControlsAutomatic(
-          userMediaAudio,
-          audioStreaming,
-          userMediaVideo,
-          cameraStreaming,
-          displayMedia,
-          screenSharingStreaming,
-          navigate
-        );
+const MediaControlButtons: FC<Props> = (props: Props) => {
+  const [show, toggleShow] = useToggle(true);
 
+  const navigate = useNavigate();
+  const controls: MediaControlButtonProps[][] =
+    props.mode === "manual" ? getManualControls(props, navigate) : [getAutomaticControls(props, navigate)];
   return (
-    <div
-      id="controls"
-      className="flex-none flex justify-center absolute mb-16 md:mb-0 inset-x-0 bottom-0 p-2 rounded-md"
-    >
-      {controls.map(({ icon, hover, onClick, imgClasses }, index) => (
-        <MediaControlButton key={index} onClick={onClick} icon={icon} hover={hover} imgClasses={imgClasses} />
-      ))}
+    <div className="absolute bottom-0 left-1/2 -translate-x-1/2 z-50">
+      <div
+        onClick={toggleShow}
+        className="absolute w-[50px] h-[15px] bg-gray-700 left-1/2 -translate-x-1/2 top-[-15px] rounded-t-lg z-[-10] bg-opacity-70 hover:bg-gray-900 "
+      ></div>
+      {show && (
+        <div className="flex flex-wrap justify-center inset-x-0 p-2 rounded-t-md bg-gray-700 rounded-t-md z-10 bg-opacity-70">
+          {controls.map((group, index1) => (
+            <div key={index1} className="flex justify-center">
+              {group.map(({ icon, hover, onClick, imgClasses }, index2) => (
+                <MediaControlButton key={index2} onClick={onClick} icon={icon} hover={hover} imgClasses={imgClasses} />
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/assets/src/pages/room/components/MediaControlButtons.tsx
+++ b/assets/src/pages/room/components/MediaControlButtons.tsx
@@ -22,7 +22,7 @@ const getAutomaticControls = (
         icon: "/svg/mic-line.svg",
         hover: "Mute the microphone",
         onClick: () => {
-          userMediaAudio.stop();
+          userMediaAudio.disable();
           audioStreaming.setActive(false);
         },
       }
@@ -30,7 +30,8 @@ const getAutomaticControls = (
         icon: "/svg/mic-off-fill.svg",
         hover: "Unmute the microphone",
         onClick: () => {
-          userMediaAudio.start();
+          userMediaAudio.stream || userMediaAudio.start();
+          userMediaAudio.enable();
           audioStreaming.setActive(true);
         },
       },
@@ -39,7 +40,7 @@ const getAutomaticControls = (
         icon: "/svg/camera-line.svg",
         hover: "Turn off the camera",
         onClick: () => {
-          userMediaVideo.stop();
+          userMediaVideo.disable();
           cameraStreaming.setActive(false);
         },
       }
@@ -47,7 +48,8 @@ const getAutomaticControls = (
         hover: "Turn on the camera",
         icon: "/svg/camera-off-line.svg",
         onClick: () => {
-          userMediaVideo.start();
+          userMediaVideo.stream || userMediaVideo.start();
+          userMediaVideo.enable();
           cameraStreaming.setActive(true);
         },
       },

--- a/assets/src/pages/room/components/StreamPlayer/MediaPlayerPeersSection.tsx
+++ b/assets/src/pages/room/components/StreamPlayer/MediaPlayerPeersSection.tsx
@@ -74,6 +74,9 @@ type Props = {
   webrtc?: MembraneWebRTC;
 };
 
+const isLoading = (track: TrackWithId) => track?.stream === undefined && track?.metadata?.active === true;
+const showDisabledIcon = (track: TrackWithId) => track?.stream === undefined || track?.metadata?.active === false;
+
 const MediaPlayerPeersSection: FC<Props> = ({
   peers,
   localUser,
@@ -82,7 +85,10 @@ const MediaPlayerPeersSection: FC<Props> = ({
   webrtc,
   showDeveloperInfo,
 }: Props) => {
-  const allPeersConfig: MediaPlayerTileConfig[] = [localUser, ...mapRemotePeersToMediaPlayerConfig(peers, showSimulcast)];
+  const allPeersConfig: MediaPlayerTileConfig[] = [
+    localUser,
+    ...mapRemotePeersToMediaPlayerConfig(peers, showSimulcast),
+  ];
 
   return (
     <div
@@ -202,15 +208,30 @@ const MediaPlayerPeersSection: FC<Props> = ({
                 <InfoLayer
                   bottomLeft={<div>{config.displayName}</div>}
                   topLeft={
-                    audio?.metadata?.active ? undefined : (
-                      <img
-                        className={`invert group-disabled:invert-80`}
-                        height="26"
-                        width="26"
-                        src="/svg/mic-off-fill.svg"
-                        alt="Microphone muted icon"
-                      />
-                    )
+                    <div className="flex flex-row">
+                      {showDisabledIcon(audio) && (
+                        <img
+                          className={clsx(`invert group-disabled:invert-80 m-1`, {
+                            "animate-spin": isLoading(audio),
+                          })}
+                          height="26"
+                          width="26"
+                          src="/svg/mic-off-fill.svg"
+                          alt="Microphone muted icon"
+                        />
+                      )}
+                      {showDisabledIcon(video) && (
+                        <img
+                          className={clsx(`invert group-disabled:invert-80 m-1`, {
+                            "animate-spin": isLoading(video),
+                          })}
+                          height="26"
+                          width="26"
+                          src="/svg/camera-off-line.svg"
+                          alt="Camera disabled icon"
+                        />
+                      )}
+                    </div>
                   }
                 />
               </>

--- a/assets/src/pages/room/hooks/useMembraneClient.tsx
+++ b/assets/src/pages/room/hooks/useMembraneClient.tsx
@@ -66,6 +66,13 @@ export const useMembraneClient = (
             }))
           );
         },
+        onTrackAdded: (ctx) => {
+          if (!ctx?.peer) return;
+          const metadata: TrackMetadata = parseMetadata(ctx);
+          // In onTrackAdded method we know, that peer has just added a new track, but right now, the server is still processing it.
+          // We register this empty track (with mediaStreamTrack and mediaStream set to undefined) to show the loading indicator.
+          api.addTrack(ctx.peer.id, ctx.trackId, undefined, undefined, metadata);
+        },
         onTrackReady: (ctx) => {
           if (!ctx?.peer || !ctx?.track || !ctx?.stream) return;
           const metadata: TrackMetadata = parseMetadata(ctx);


### PR DESCRIPTION
This is not fix for MV-233. It's only a workaround. In this PR I only change the behavior of media control buttons, to minimalize the negative impact of this bug. Now stop/start buttons only disable tracks, so we are sending media streams full of black pixels or empty audio. The camera as a device is active all the time, we don't disable the camera after a button press. ScreenSharing still generates new media sections. 

Other improvements:
- camera on / off indicator
<img width="110" alt="image" src="https://user-images.githubusercontent.com/19818474/205287230-52c7ff71-47ce-465f-8af0-cdc6eec4e620.png">
- loading stream indicator - icons animate between "onTrackAdded" and "onTrackReady"
<img width="107" alt="image" src="https://user-images.githubusercontent.com/19818474/205287493-49f3915a-5b40-4313-a9b6-4c9b9e5dbc45.png">
- media control buttons background
<img width="318" alt="image" src="https://user-images.githubusercontent.com/19818474/205287787-de0b2d59-e12d-4104-871f-78848d72936c.png">
- ability to show / hide media control buttons
<img width="295" alt="image" src="https://user-images.githubusercontent.com/19818474/205287948-fcbf3003-14c1-4931-824a-e3247ff5b976.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/19818474/205288066-43ad9247-d328-4368-babf-7d9042a42114.png">
