### PR TITLE
Turn simulcast on by default

### DIFF
--- a/assets/src/pages/home/HomePage.tsx
+++ b/assets/src/pages/home/HomePage.tsx
@@ -23,7 +23,7 @@ export const HomePage: FC = () => {
 
   const [autostartCameraAndMicInput, setAutostartCameraAndMicCheckbox] = useToggle(true);
 
-  const simulcastParam: string = searchParams?.get("simulcast") || "";
+  const simulcastParam: string = searchParams?.get("simulcast") || "true";
   const simulcastDefaultValue: boolean = simulcastParam === "true";
   const [simulcastInput, toggleSimulcastCheckbox] = useToggle(simulcastDefaultValue);
 


### PR DESCRIPTION
A lot of unsuccessful calls are caused by someone creating a room without simulcast and someone other joining it with simulcast.

We should also test simulcast on our daily basis so I would propose to turn it on by default.