### PR TITLE
Fix non-simulcast bitrate limits

### DIFF
--- a/assets/src/pages/room/hooks/useMembraneMediaStreaming.tsx
+++ b/assets/src/pages/room/hooks/useMembraneMediaStreaming.tsx
@@ -23,7 +23,7 @@ export const useMembraneMediaStreaming = (
   mode: StreamingMode,
   type: TrackType,
   isConnected: boolean,
-  simulcast: boolean,
+  simulcastEnabled: boolean,
   webrtc?: MembraneWebRTC,
   stream?: MediaStream
 ): MembraneStreaming => {
@@ -36,6 +36,7 @@ export const useMembraneMediaStreaming = (
     (stream: MediaStream) => {
       if (!webrtc) return;
       const tracks = type === "audio" ? stream.getAudioTracks() : stream.getVideoTracks();
+      const simulcast = simulcastEnabled && type === "camera";
 
       const track: MediaStreamTrack | undefined = tracks[0];
       if (!track) throw "Stream has no tracks!";
@@ -44,14 +45,14 @@ export const useMembraneMediaStreaming = (
         track,
         stream,
         defaultTrackMetadata,
-        type == "camera" && simulcast ? { enabled: true, active_encodings: ["l", "m", "h"] } : undefined,
+        simulcast ? { enabled: true, active_encodings: ["l", "m", "h"] } : undefined,
         selectBandwidthLimit(type, simulcast)
       );
 
       setTrackIds({ localId: track.id, remoteId: remoteTrackId });
       setTrackMetadata(defaultTrackMetadata);
     },
-    [defaultTrackMetadata, simulcast, type, webrtc]
+    [defaultTrackMetadata, simulcastEnabled, type, webrtc]
   );
 
   const replaceTrack = useCallback(


### PR DESCRIPTION
A different condition was taken into account when enabling simulcast and when fetching bitrate limits. As a result, when simulcast was enabled, a non-simulcast screenshare
was getting simulcast bitrate limits, which were not correctly applied by the SDK
