### PR TITLE
Mv 246 video tile redesign

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -52,11 +52,14 @@ Don't display screensharing control on mobile browsers
   max-height: calc(100vh - 16px - 48px - 16px - 16px - 43px - 16px);
 }
 
+/* allows for centering leftover elements in the last row of the grid */
 @media (min-width: 769px) {
+  /* two colums -> one element left*/
   .video-tile-grid-2:last-child:nth-child(2n - 1) {
     grid-column-end: 4;
   }
 
+  /* three columns -> two elements left */
   .video-tile-grid-3:last-child:nth-child(3n - 1) {
     grid-column-end: -2;
   }
@@ -65,10 +68,12 @@ Don't display screensharing control on mobile browsers
     grid-column-end: 4;
   }
 
+  /* three columns -> one element left */
   .video-tile-grid-3:last-child:nth-child(3n - 2) {
     grid-column-end: 5;
   }
 
+  /* four columns -> two elements left */
   .video-tile-grid-4:last-child:nth-child(4n + 2) {
     grid-column-end: -3;
   }
@@ -77,6 +82,7 @@ Don't display screensharing control on mobile browsers
     grid-column-end: 5;
   }
 
+  /* four columns -> three elements left */
   .video-tile-grid-4:last-child:nth-child(4n + 3) {
     grid-column-end: 8;
   }
@@ -89,6 +95,7 @@ Don't display screensharing control on mobile browsers
     grid-column-end: 4;
   }
 
+  /* four columns -> one element left */
   .video-tile-grid-4:last-child:nth-child(4n - 3) {
     grid-column-end: 6;
   }

--- a/assets/src/features/room-page/components/InitialsImage.tsx
+++ b/assets/src/features/room-page/components/InitialsImage.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+export const computeInitials = (name: string): string => {
+  return name
+    .split(" ")
+    .map((word) => word.charAt(0))
+    .join("")
+    .toLocaleUpperCase();
+};
+
+type InitialsImageProps = {
+  initials: string;
+};
+
+const InitialsImage = ({ initials }: InitialsImageProps) => {
+  return (
+    <div className="flex h-full w-full flex-wrap content-center justify-center bg-brand-sea-blue-100">
+      <div className="flex h-32 w-32 flex-wrap content-center justify-center rounded-full border border-brand-dark-blue-200">
+        <span className="font-roc-grotesk text-lg font-medium text-brand-dark-blue-400">{initials}</span>
+      </div>
+    </div>
+  );
+};
+
+export default InitialsImage;

--- a/assets/src/features/room-page/components/NameTag.tsx
+++ b/assets/src/features/room-page/components/NameTag.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { LOCAL_PEER_NAME } from "../../../pages/room/consts";
+
+type NameTagProps = {
+  name: string;
+};
+
+const NameTag = ({ name }: NameTagProps) => {
+  const isMyself = name === LOCAL_PEER_NAME;
+  const bgColor = isMyself ? "bg-brand-pink-500" : "bg-brand-dark-blue-400";
+
+  return (
+    <div className={`${bgColor} gap-1 rounded-full px-3 py-1`}>
+      <span className="text-sm ">{name}</span>
+    </div>
+  );
+};
+
+export default NameTag;

--- a/assets/src/pages/room/VideochatSection.tsx
+++ b/assets/src/pages/room/VideochatSection.tsx
@@ -76,13 +76,14 @@ export const VideochatSection: FC<Props> = ({ peers, localPeer, showSimulcast, w
   };
 
   const { screenSharingStreams, isScreenSharingActive } = prepareScreenSharingStreams(peers, localPeer);
+  const noPeers = !peers.length;
 
   return (
     <div id="videochat" className="grid-wrapper align-center flex h-full w-full justify-center">
       <div
         className={clsx(
           "grid h-full w-full auto-rows-fr gap-3 3xl:max-w-[1728px]",
-          isScreenSharingActive && "sm:grid-cols-3/1"
+          isScreenSharingActive && (noPeers ? "relative" : "sm:grid-cols-3/1")
         )}
       >
         {isScreenSharingActive && <ScreenSharingPlayers streams={screenSharingStreams || []} />}

--- a/assets/src/pages/room/VideochatSection.tsx
+++ b/assets/src/pages/room/VideochatSection.tsx
@@ -1,10 +1,12 @@
+import React, { FC } from "react";
+
 import { LocalPeer, RemotePeer } from "./hooks/usePeerState";
 import MediaPlayerPeersSection, { MediaPlayerTileConfig } from "./components/StreamPlayer/MediaPlayerPeersSection";
 import { MembraneWebRTC } from "@jellyfish-dev/membrane-webrtc-js";
 import ScreenSharingPlayers, { VideoStreamWithMetadata } from "./components/StreamPlayer/ScreenSharingPlayers";
-import React, { FC } from "react";
 import { LOCAL_PEER_NAME, LOCAL_SCREEN_SHARING_ID, LOCAL_VIDEO_ID } from "./consts";
 import clsx from "clsx";
+import { computeInitials } from "../../features/room-page/components/InitialsImage";
 
 type Props = {
   peers: RemotePeer[];
@@ -64,7 +66,7 @@ export const VideochatSection: FC<Props> = ({ peers, localPeer, showSimulcast, w
   const localUser: MediaPlayerTileConfig = {
     peerId: localPeer?.id,
     displayName: LOCAL_PEER_NAME,
-    emoji: localPeer?.metadata?.emoji,
+    initials: computeInitials(localPeer?.metadata?.displayName || ""),
     video: localPeer?.tracks["camera"] ? [localPeer?.tracks["camera"]] : [],
     audio: localPeer?.tracks["audio"] ? [localPeer?.tracks["audio"]] : [],
     screenSharing: localPeer?.tracks["screensharing"] ? [localPeer?.tracks["screensharing"]] : [],

--- a/assets/src/pages/room/components/StreamPlayer/MediaPlayer.tsx
+++ b/assets/src/pages/room/components/StreamPlayer/MediaPlayer.tsx
@@ -6,7 +6,7 @@ export interface Props {
   videoStream?: MediaStream;
   audioStream?: MediaStream;
   playAudio?: boolean;
-  screenShare?: boolean;
+  blockFillContent?: boolean;
 }
 
 const MediaPlayer: React.FC<Props> = ({
@@ -14,7 +14,7 @@ const MediaPlayer: React.FC<Props> = ({
   audioStream,
   flipHorizontally,
   playAudio,
-  screenShare,
+  blockFillContent,
 }: Props) => {
   const videoRef: RefObject<HTMLVideoElement> = useRef<HTMLVideoElement>(null);
   const audioRef: RefObject<HTMLAudioElement> = useRef<HTMLAudioElement>(null);
@@ -40,7 +40,7 @@ const MediaPlayer: React.FC<Props> = ({
     };
 
     const setFillContentState = (videoElement: HTMLVideoElement): void => {
-      const newValue = isVideoHorizontal(videoElement) && !screenShare;
+      const newValue = !blockFillContent && isVideoHorizontal(videoElement);
       shouldFillContent(newValue);
     };
 
@@ -55,7 +55,7 @@ const MediaPlayer: React.FC<Props> = ({
     return () => {
       if (video) video.onresize = null;
     };
-  }, [videoStream, fillContent, screenShare]);
+  }, [videoStream, fillContent, blockFillContent]);
 
   return (
     <>

--- a/assets/src/pages/room/components/StreamPlayer/MediaPlayer.tsx
+++ b/assets/src/pages/room/components/StreamPlayer/MediaPlayer.tsx
@@ -1,38 +1,84 @@
-import React, { RefObject, useEffect, useRef } from "react";
+import React, { RefObject, useEffect, useRef, useState } from "react";
 import clsx from "clsx";
 
 export interface Props {
+  cameraOffImage: JSX.Element | null;
   flipHorizontally?: boolean;
   videoStream?: MediaStream;
   audioStream?: MediaStream;
   playAudio?: boolean;
+  screenShare?: boolean;
 }
 
-const MediaPlayer: React.FC<Props> = ({ videoStream, audioStream, flipHorizontally, playAudio }: Props) => {
+const MediaPlayer: React.FC<Props> = ({
+  videoStream,
+  audioStream,
+  flipHorizontally,
+  playAudio,
+  cameraOffImage,
+  screenShare,
+}: Props) => {
   const videoRef: RefObject<HTMLVideoElement> = useRef<HTMLVideoElement>(null);
   const audioRef: RefObject<HTMLAudioElement> = useRef<HTMLAudioElement>(null);
+  const showInitials = !screenShare && cameraOffImage !== null;
+
+  const [fillContent, shouldFillContent] = useState<boolean>(true);
 
   useEffect(() => {
     if (!videoRef.current) return;
     videoRef.current.srcObject = videoStream || null;
-  }, [videoStream]);
+  }, [videoStream, showInitials]);
 
   useEffect(() => {
     if (!audioRef.current) return;
     audioRef.current.srcObject = audioStream || null;
   }, [audioStream]);
 
+  useEffect(() => {
+    const isVideoHorizontal = (video: HTMLVideoElement): boolean => {
+      const width = video.videoWidth;
+      const height = video.videoHeight;
+
+      return width > height;
+    };
+
+    const setFillContentState = (videoElement: HTMLVideoElement): void => {
+      const newValue = isVideoHorizontal(videoElement) && !screenShare;
+      shouldFillContent(newValue);
+    };
+
+    const video = videoRef.current;
+    if (video) {
+      video.onresize = () => {
+        const videoElement = video;
+        if (videoElement) setFillContentState(videoElement);
+      };
+    }
+
+    return () => {
+      if (video) video.onresize = null;
+    };
+  }, [videoStream, fillContent, screenShare]);
+
   return (
     <>
       <audio muted={!playAudio} autoPlay ref={audioRef} />
-      <video
-        className={clsx(flipHorizontally && "flip-horizontally")}
-        autoPlay
-        playsInline
-        controls={false}
-        muted
-        ref={videoRef}
-      />
+      {showInitials ? (
+        cameraOffImage
+      ) : (
+        <video
+          className={clsx(
+            "h-full w-full",
+            flipHorizontally && "flip-horizontally",
+            fillContent ? "object-cover" : "object-contain"
+          )}
+          autoPlay
+          playsInline
+          controls={false}
+          muted
+          ref={videoRef}
+        />
+      )}
     </>
   );
 };

--- a/assets/src/pages/room/components/StreamPlayer/MediaPlayerPeersSection.tsx
+++ b/assets/src/pages/room/components/StreamPlayer/MediaPlayerPeersSection.tsx
@@ -4,11 +4,11 @@ import MediaPlayerTile from "./MediaPlayerTile";
 import { MembraneWebRTC, TrackEncoding } from "@jellyfish-dev/membrane-webrtc-js";
 import clsx from "clsx";
 import { StreamSource, TrackType } from "../../../types";
-import InfoLayer from "./PeerInfoLayer";
 import PeerInfoLayer from "./PeerInfoLayer";
 import MicrophoneOff from "../../../../features/room-page/icons/MicrophoneOff";
-import CameraOff from "../../../../features/room-page/icons/CameraOff";
 import { getGridConfig } from "../../../../features/room-page/utils/getVideoGridConfig";
+import NameTag from "../../../../features/room-page/components/NameTag";
+import InitialsImage, { computeInitials } from "../../../../features/room-page/components/InitialsImage";
 
 export type TrackWithId = {
   stream?: MediaStream;
@@ -20,9 +20,9 @@ export type TrackWithId = {
 
 export type MediaPlayerTileConfig = {
   peerId?: string;
-  emoji?: string;
   flipHorizontally?: boolean;
   displayName?: string;
+  initials: string;
   video: TrackWithId[];
   audio: TrackWithId[];
   playAudio: boolean;
@@ -54,8 +54,8 @@ const mapRemotePeersToMediaPlayerConfig = (peers: RemotePeer[], showSimulcast?: 
 
     return {
       peerId: peer.id,
-      emoji: peer.emoji,
       displayName: peer.displayName,
+      initials: computeInitials(peer.displayName || ""),
       video: videoTracks,
       audio: audioTracks,
       screenSharing: screenSharingTracks,
@@ -67,6 +67,18 @@ const mapRemotePeersToMediaPlayerConfig = (peers: RemotePeer[], showSimulcast?: 
       mediaPlayerId: peer.id,
     };
   });
+};
+
+type DisabledMicIconProps = {
+  isLoading: boolean;
+};
+
+const DisabledMicIcon = ({ isLoading }: DisabledMicIconProps) => {
+  return (
+    <div className="flex h-8 w-8 flex-wrap content-center justify-center rounded-full bg-white">
+      <MicrophoneOff className={isLoading ? "animate-spin" : ""} fill="#001A72" />
+    </div>
+  );
 };
 
 type Props = {
@@ -95,8 +107,7 @@ const MediaPlayerPeersSection: FC<Props> = ({
     ...mapRemotePeersToMediaPlayerConfig(peers, showSimulcast),
   ];
 
-  const gridConfig = getGridConfig(allPeersConfig.length);
-  function getGridStyle() {
+  const getGridStyle = () => {
     const noPeers = !peers.length;
 
     if (oneColumn) {
@@ -109,9 +120,11 @@ const MediaPlayerPeersSection: FC<Props> = ({
     } else {
       return clsx(gridConfig.columns, gridConfig.grid, gridConfig.gap, gridConfig.padding, gridConfig.rows);
     }
-  }
+  };
 
+  const gridConfig = getGridConfig(allPeersConfig.length);
   const videoGridStyle = getGridStyle();
+  const tileSize = allPeersConfig.length >= 7 ? "M" : "L";
 
   return (
     <div id="videos-grid" className={clsx("h-full w-full", videoGridStyle)}>
@@ -121,7 +134,6 @@ const MediaPlayerPeersSection: FC<Props> = ({
         const screenSharing: TrackWithId | undefined = config.screenSharing[0];
         const audio: TrackWithId | undefined = config.audio[0];
 
-        const emoji = config.emoji || "";
         const localAudio = config.playAudio ? { emoji: "🔊", title: "Playing" } : { emoji: "🔇", title: "Muted" };
 
         // todo refactor to separate component / layer
@@ -148,11 +160,11 @@ const MediaPlayerPeersSection: FC<Props> = ({
             video={video}
             audioStream={audio?.stream}
             className={!oneColumn ? clsx(gridConfig.span, gridConfig.tileClass) : undefined}
+            cameraOffImage={showDisabledIcon(video) ? <InitialsImage initials={config.initials} /> : null}
             layers={
               <>
                 {showDeveloperInfo && (
                   <PeerInfoLayer
-                    topLeft={<div>{emoji}</div>}
                     topRight={
                       <div>
                         <div className="text-right">
@@ -223,16 +235,14 @@ const MediaPlayerPeersSection: FC<Props> = ({
                     }
                   />
                 )}
-                <InfoLayer
-                  bottomLeft={<div>{config.displayName}</div>}
+                <PeerInfoLayer
+                  bottomLeft={<NameTag name={config.displayName || "Unknown"} />}
                   topLeft={
                     <div className="flex flex-row items-center gap-x-2 text-xl">
-                      {showDisabledIcon(audio) && (
-                        <MicrophoneOff className={clsx(isLoading(audio) && "animate-spin")} />
-                      )}
-                      {showDisabledIcon(video) && <CameraOff className={clsx(isLoading(audio) && "animate-spin")} />}
+                      {showDisabledIcon(audio) && <DisabledMicIcon isLoading={isLoading(audio)} />}
                     </div>
                   }
+                  tileSize={tileSize}
                 />
               </>
             }

--- a/assets/src/pages/room/components/StreamPlayer/MediaPlayerPeersSection.tsx
+++ b/assets/src/pages/room/components/StreamPlayer/MediaPlayerPeersSection.tsx
@@ -96,17 +96,25 @@ const MediaPlayerPeersSection: FC<Props> = ({
   ];
 
   const gridConfig = getGridConfig(allPeersConfig.length);
+  function getGridStyle() {
+    const noPeers = !peers.length;
+
+    if (oneColumn) {
+      if (noPeers) {
+        // display video positioned absolute in another video
+        return "absolute bottom-4 right-4 z-10 h-[220px] w-[400px]";
+      } else {
+        return "grid flex-1 grid-flow-row auto-rows-fr grid-cols-1 gap-y-3";
+      }
+    } else {
+      return clsx(gridConfig.columns, gridConfig.grid, gridConfig.gap, gridConfig.padding, gridConfig.rows);
+    }
+  }
+
+  const videoGridStyle = getGridStyle();
 
   return (
-    <div
-      id="videos-grid"
-      className={clsx(
-        "h-full w-full",
-        oneColumn
-          ? "grid flex-1 grid-flow-row auto-rows-fr grid-cols-1 gap-y-3"
-          : clsx(gridConfig.columns, gridConfig.grid, gridConfig.gap, gridConfig.padding, gridConfig.rows)
-      )}
-    >
+    <div id="videos-grid" className={clsx("h-full w-full", videoGridStyle)}>
       {allPeersConfig.map((config) => {
         // todo for now only first audio, video and screen sharing stream are handled
         const video: TrackWithId | undefined = config.video[0];

--- a/assets/src/pages/room/components/StreamPlayer/MediaPlayerTile.tsx
+++ b/assets/src/pages/room/components/StreamPlayer/MediaPlayerTile.tsx
@@ -20,6 +20,8 @@ export interface Props {
   layers?: JSX.Element;
   webrtc?: MembraneWebRTC;
   className?: string;
+  screenShare?: boolean;
+  cameraOffImage: JSX.Element | null;
 }
 
 const MediaPlayerTile: FC<Props> = ({
@@ -33,6 +35,8 @@ const MediaPlayerTile: FC<Props> = ({
   layers,
   webrtc,
   className,
+  cameraOffImage,
+  screenShare,
 }: Props) => {
   const { desiredEncoding, setDesiredEncoding } = useSimulcastRemoteEncoding("m", peerId, video?.remoteTrackId, webrtc);
 
@@ -43,7 +47,7 @@ const MediaPlayerTile: FC<Props> = ({
       data-name="video-feed"
       className={clsx(
         className,
-        "relative flex h-full w-full justify-center overflow-hidden rounded-lg bg-gray-900 shadow"
+        "relative flex h-full w-full justify-center overflow-hidden rounded-xl border border-brand-dark-blue-300 bg-gray-900"
       )}
     >
       <MediaPlayer
@@ -51,6 +55,8 @@ const MediaPlayerTile: FC<Props> = ({
         audioStream={audioStream}
         flipHorizontally={flipHorizontally}
         playAudio={playAudio}
+        cameraOffImage={cameraOffImage}
+        screenShare={screenShare}
       />
       {layers}
       {showSimulcast && streamSource === "remote" && (

--- a/assets/src/pages/room/components/StreamPlayer/MediaPlayerTile.tsx
+++ b/assets/src/pages/room/components/StreamPlayer/MediaPlayerTile.tsx
@@ -20,7 +20,7 @@ export interface Props {
   layers?: JSX.Element;
   webrtc?: MembraneWebRTC;
   className?: string;
-  screenShare?: boolean;
+  blockFillContent?: boolean;
 }
 
 const MediaPlayerTile: FC<Props> = ({
@@ -34,7 +34,7 @@ const MediaPlayerTile: FC<Props> = ({
   layers,
   webrtc,
   className,
-  screenShare,
+  blockFillContent,
 }: Props) => {
   const { desiredEncoding, setDesiredEncoding } = useSimulcastRemoteEncoding("m", peerId, video?.remoteTrackId, webrtc);
 
@@ -53,7 +53,7 @@ const MediaPlayerTile: FC<Props> = ({
         audioStream={audioStream}
         flipHorizontally={flipHorizontally}
         playAudio={playAudio}
-        screenShare={screenShare}
+        blockFillContent={blockFillContent}
       />
       {layers}
       {showSimulcast && streamSource === "remote" && (

--- a/assets/src/pages/room/components/StreamPlayer/PeerInfoLayer.tsx
+++ b/assets/src/pages/room/components/StreamPlayer/PeerInfoLayer.tsx
@@ -1,10 +1,12 @@
 import React, { FC } from "react";
+import clsx from "clsx";
 
 type Props = {
   topLeft?: JSX.Element;
   topRight?: JSX.Element;
   bottomLeft?: JSX.Element;
   bottomRight?: JSX.Element;
+  tileSize?: "M" | "L";
 };
 
 type Corner = {
@@ -13,7 +15,7 @@ type Corner = {
   content?: JSX.Element;
 };
 
-const PeerInfoLayer: FC<Props> = ({ topLeft, topRight, bottomLeft, bottomRight }: Props) => {
+const PeerInfoLayer: FC<Props> = ({ topLeft, topRight, bottomLeft, bottomRight, tileSize = "L" }: Props) => {
   const corners: Corner[] = [
     { x: "left", y: "top", content: topLeft },
     { x: "right", y: "top", content: topRight },
@@ -21,13 +23,15 @@ const PeerInfoLayer: FC<Props> = ({ topLeft, topRight, bottomLeft, bottomRight }
     { x: "right", y: "bottom", content: bottomRight },
   ];
 
+  const paddingClassName = { M: "p-3", L: "p-4" };
+
   return (
     <>
       {corners.map((corner) => (
         <div
           key={`${corner.x}-${corner.y}`}
           data-name="video-label"
-          className={`text-shadow-lg absolute text-white ${corner.x}-0 ${corner.y}-0 p-2`}
+          className={clsx(`absolute text-white ${corner.x}-0 ${corner.y}-0`, paddingClassName[tileSize])}
         >
           {corner.content}
         </div>

--- a/assets/src/pages/room/components/StreamPlayer/ScreenSharingPlayers.tsx
+++ b/assets/src/pages/room/components/StreamPlayer/ScreenSharingPlayers.tsx
@@ -2,6 +2,7 @@ import React, { FC } from "react";
 import MediaPlayerTile from "./MediaPlayerTile";
 import { TrackWithId } from "./MediaPlayerPeersSection";
 import PeerInfoLayer from "./PeerInfoLayer";
+import NameTag from "../../../../features/room-page/components/NameTag";
 
 export type VideoStreamWithMetadata = {
   mediaPlayerId: string;
@@ -20,18 +21,12 @@ const ScreenSharingPlayers: FC<Props> = ({ streams }: Props) => {
     <div className="active-screensharing-grid h-full grid-cols-1">
       {streams.map((config) => (
         <MediaPlayerTile
+          screenShare
           key={config.mediaPlayerId}
           video={config.video}
           streamSource={"local"}
-          layers={
-            <PeerInfoLayer
-              bottomLeft={
-                <div>
-                  ({config.peerIcon} {config.peerName}) Screen
-                </div>
-              }
-            />
-          }
+          cameraOffImage={null}
+          layers={<PeerInfoLayer bottomLeft={<NameTag name={config.peerName || "Unknown"} />} />}
         />
       ))}
     </div>

--- a/assets/src/pages/room/components/StreamPlayer/ScreenSharingPlayers.tsx
+++ b/assets/src/pages/room/components/StreamPlayer/ScreenSharingPlayers.tsx
@@ -21,11 +21,10 @@ const ScreenSharingPlayers: FC<Props> = ({ streams }: Props) => {
     <div className="active-screensharing-grid h-full grid-cols-1">
       {streams.map((config) => (
         <MediaPlayerTile
-          screenShare
+          blockFillContent
           key={config.mediaPlayerId}
           video={config.video}
           streamSource={"local"}
-          cameraOffImage={null}
           layers={<PeerInfoLayer bottomLeft={<NameTag name={config.peerName || "Unknown"} />} />}
         />
       ))}

--- a/assets/src/pages/room/consts.ts
+++ b/assets/src/pages/room/consts.ts
@@ -34,7 +34,7 @@ export const VIDEO_TRACKS_CONFIG = new MediaStreamConfig(VIDEO_TRACK_CONSTRAINTS
 export const AUDIO_TRACKS_CONFIG = new MediaStreamConfig(AUDIO_TRACK_CONSTRAINTS);
 export const SCREEN_SHARING_TRACKS_CONFIG = new DisplayMediaStreamConfig(SCREENSHARING_MEDIA_CONSTRAINTS);
 
-export const LOCAL_PEER_NAME = "Me";
+export const LOCAL_PEER_NAME = "You";
 export const LOCAL_VIDEO_ID = "LOCAL_VIDEO_ID";
 export const LOCAL_SCREEN_SHARING_ID = "LOCAL_SCREEN_SHARING_ID";
 

--- a/assets/src/pages/room/hooks/useMembraneMediaStreaming.tsx
+++ b/assets/src/pages/room/hooks/useMembraneMediaStreaming.tsx
@@ -23,7 +23,7 @@ export const useMembraneMediaStreaming = (
   mode: StreamingMode,
   type: TrackType,
   isConnected: boolean,
-  simulcast: boolean,
+  simulcastEnabled: boolean,
   webrtc?: MembraneWebRTC,
   stream?: MediaStream
 ): MembraneStreaming => {
@@ -36,6 +36,7 @@ export const useMembraneMediaStreaming = (
     (stream: MediaStream) => {
       if (!webrtc) return;
       const tracks = type === "audio" ? stream.getAudioTracks() : stream.getVideoTracks();
+      const simulcast = simulcastEnabled && type === "camera";
 
       const track: MediaStreamTrack | undefined = tracks[0];
       if (!track) throw "Stream has no tracks!";
@@ -44,14 +45,14 @@ export const useMembraneMediaStreaming = (
         track,
         stream,
         defaultTrackMetadata,
-        type == "camera" && simulcast ? { enabled: true, active_encodings: ["l", "m", "h"] } : undefined,
+        simulcast ? { enabled: true, active_encodings: ["l", "m", "h"] } : undefined,
         selectBandwidthLimit(type, simulcast)
       );
 
       setTrackIds({ localId: track.id, remoteId: remoteTrackId });
       setTrackMetadata(defaultTrackMetadata);
     },
-    [defaultTrackMetadata, simulcast, type, webrtc]
+    [defaultTrackMetadata, simulcastEnabled, type, webrtc]
   );
 
   const replaceTrack = useCallback(


### PR DESCRIPTION
In this PR:
  - the video tile is restyled
  - camera icon is deleted and a screen with user's initials is displayed while the camera is off
  - the micOff icon has be refurbished
  - the name tag has been restyled
  - video content is trimmed when the user has a horizontal video input source but there is padding (background is visible and there is no trimming) if the source is vertical or the user shares the screen 