### PR TITLE
Deleting show developer info button

### DIFF
--- a/assets/src/pages/room/RoomPage.tsx
+++ b/assets/src/pages/room/RoomPage.tsx
@@ -8,11 +8,11 @@ import { VideochatSection } from "./VideochatSection";
 import { getRandomAnimalEmoji } from "./utils";
 import { useStreamManager } from "./hooks/useStreamManager";
 import { StreamingMode } from "./hooks/useMembraneMediaStreaming";
-import { useAcquireWakeLockAutomatically } from "./hooks/useAcquireWakeLockAutomatically";
 import PageLayout from "../../features/room-page/components/PageLayout";
 import useToast from "../../features/shared/hooks/useToast";
 import useEffectOnChange from "../../features/shared/hooks/useEffectOnChange";
 import { ErrorMessage, messageComparator } from "./errorMessage";
+import { useAcquireWakeLockAutomatically } from "./hooks/useAcquireWakeLockAutomatically";
 
 type Props = {
   displayName: string;
@@ -23,7 +23,7 @@ type Props = {
 };
 
 const RoomPage: FC<Props> = ({ roomId, displayName, isSimulcastOn, manualMode, autostartStreaming }: Props) => {
-  const wakeLock = useAcquireWakeLockAutomatically();
+  useAcquireWakeLockAutomatically();
 
   const mode: StreamingMode = manualMode ? "manual" : "automatic";
 
@@ -108,7 +108,7 @@ const RoomPage: FC<Props> = ({ roomId, displayName, isSimulcastOn, manualMode, a
         />
 
         {/* dev helpers */}
-        <div className="invisible absolute bottom-3 right-3 flex flex-row items-stretch md:visible">
+        <div className="invisible absolute bottom-3 right-3 flex flex-col items-stretch md:visible">
           {isSimulcastOn && (
             <button
               onClick={toggleSimulcastMenu}
@@ -118,9 +118,6 @@ const RoomPage: FC<Props> = ({ roomId, displayName, isSimulcastOn, manualMode, a
               Show simulcast controls
             </button>
           )}
-          <div className="m-1 rounded bg-brand-grey-100 p-2 text-right text-brand-white">
-            <span className="whitespace-nowrap">WakeLock {wakeLock.isSupported ? "🟢" : "🔴"}</span>
-          </div>
         </div>
       </div>
     </PageLayout>

--- a/assets/src/pages/room/RoomPage.tsx
+++ b/assets/src/pages/room/RoomPage.tsx
@@ -10,7 +10,6 @@ import { useStreamManager } from "./hooks/useStreamManager";
 import { StreamingMode } from "./hooks/useMembraneMediaStreaming";
 import { useAcquireWakeLockAutomatically } from "./hooks/useAcquireWakeLockAutomatically";
 import PageLayout from "../../features/room-page/components/PageLayout";
-import Button from "../../features/shared/components/Button";
 import useToast from "../../features/shared/hooks/useToast";
 import useEffectOnChange from "../../features/shared/hooks/useEffectOnChange";
 import { ErrorMessage, messageComparator } from "./errorMessage";
@@ -30,7 +29,6 @@ const RoomPage: FC<Props> = ({ roomId, displayName, isSimulcastOn, manualMode, a
 
   const [errorMessage, setErrorMessage] = useState<ErrorMessage | undefined>();
   const [showSimulcastMenu, toggleSimulcastMenu] = useToggle(false);
-  const [showDeveloperInfo, toggleDeveloperInfo] = useToggle(false);
   const [peerMetadata] = useState<PeerMetadata>({ emoji: getRandomAnimalEmoji(), displayName });
 
   const { state: peerState, api: peerApi } = usePeersState();
@@ -91,17 +89,10 @@ const RoomPage: FC<Props> = ({ roomId, displayName, isSimulcastOn, manualMode, a
       <div className="flex h-full w-full flex-col gap-y-4">
         {/* main grid - videos + future chat */}
         <section className="flex h-full w-full flex-col">
-          {showDeveloperInfo && (
-            <div className="text-shadow-lg absolute right-0 top-0 flex flex-col p-2 text-right">
-              <span className="ml-2">Is WakeLock supported: {wakeLock.isSupported ? "🟢" : "🔴"}</span>
-            </div>
-          )}
-
           <VideochatSection
             peers={peerState.remote}
             localPeer={peerState.local}
             showSimulcast={showSimulcastMenu}
-            showDeveloperInfo={showDeveloperInfo}
             webrtc={webrtc}
           />
         </section>
@@ -117,22 +108,19 @@ const RoomPage: FC<Props> = ({ roomId, displayName, isSimulcastOn, manualMode, a
         />
 
         {/* dev helpers */}
-        <div className="invisible absolute bottom-4 right-3 flex flex-col items-stretch md:visible">
+        <div className="invisible absolute bottom-3 right-3 flex flex-row items-stretch md:visible">
           {isSimulcastOn && (
             <button
               onClick={toggleSimulcastMenu}
-              className="focus:outline-none focus:shadow-outline m-1 w-full rounded bg-gray-700 py-2 px-4 text-white hover:bg-gray-900"
+              className="focus:outline-none focus:shadow-outline m-1 w-full rounded bg-brand-grey-80 py-2 px-4 text-white hover:bg-brand-grey-100"
               type="submit"
             >
               Show simulcast controls
             </button>
           )}
-          <Button
-            onClick={toggleDeveloperInfo}
-            className="focus:outline-none focus:shadow-outline m-1 w-full rounded bg-gray-700 py-2 px-4 text-white hover:bg-gray-900"
-          >
-            {showDeveloperInfo ? "Hide developer info" : "Show developer info"}
-          </Button>
+          <div className="m-1 rounded bg-brand-grey-100 p-2 text-right text-brand-white">
+            <span className="whitespace-nowrap">WakeLock {wakeLock.isSupported ? "🟢" : "🔴"}</span>
+          </div>
         </div>
       </div>
     </PageLayout>

--- a/assets/src/pages/room/VideochatSection.tsx
+++ b/assets/src/pages/room/VideochatSection.tsx
@@ -15,7 +15,6 @@ type Props = {
   peers: RemotePeer[];
   localPeer?: LocalPeer;
   showSimulcast?: boolean;
-  showDeveloperInfo?: boolean;
   webrtc?: MembraneWebRTC;
 };
 
@@ -75,10 +74,9 @@ const prepareScreenSharingStreams = (
 const remoteTrackToLocalTrack = (localPeer: Track | undefined): TrackWithId | null =>
   localPeer ? { ...localPeer, remoteTrackId: localPeer.trackId } : null;
 
-export const VideochatSection: FC<Props> = ({ peers, localPeer, showSimulcast, webrtc, showDeveloperInfo }: Props) => {
+export const VideochatSection: FC<Props> = ({ peers, localPeer, showSimulcast, webrtc }: Props) => {
   const video: TrackWithId | null = remoteTrackToLocalTrack(localPeer?.tracks["camera"]);
   const audio: TrackWithId | null = remoteTrackToLocalTrack(localPeer?.tracks["audio"]);
-  const screenSharing: TrackWithId | null = remoteTrackToLocalTrack(localPeer?.tracks["screensharing"]);
 
   const localUser: MediaPlayerTileConfig = {
     peerId: localPeer?.id,
@@ -86,8 +84,6 @@ export const VideochatSection: FC<Props> = ({ peers, localPeer, showSimulcast, w
     initials: computeInitials(localPeer?.metadata?.displayName || ""),
     video: video ? [video] : [],
     audio: audio ? [audio] : [],
-    screenSharing: screenSharing ? [screenSharing] : [],
-    showSimulcast: showSimulcast,
     flipHorizontally: true,
     streamSource: "local",
     playAudio: false,
@@ -111,7 +107,6 @@ export const VideochatSection: FC<Props> = ({ peers, localPeer, showSimulcast, w
           peers={peers}
           localUser={localUser}
           showSimulcast={showSimulcast}
-          showDeveloperInfo={showDeveloperInfo}
           oneColumn={isScreenSharingActive}
           webrtc={webrtc}
         />

--- a/assets/src/pages/room/components/StreamPlayer/PeerInfoLayer.tsx
+++ b/assets/src/pages/room/components/StreamPlayer/PeerInfoLayer.tsx
@@ -22,7 +22,6 @@ const PeerInfoLayer: FC<Props> = ({ topLeft, topRight, bottomLeft, bottomRight, 
     { x: "left", y: "bottom", content: bottomLeft },
     { x: "right", y: "bottom", content: bottomRight },
   ];
-
   const paddingClassName = { M: "p-3", L: "p-4" };
 
   return (

--- a/assets/src/pages/room/hooks/useAcquireWakeLockAutomatically.tsx
+++ b/assets/src/pages/room/hooks/useAcquireWakeLockAutomatically.tsx
@@ -17,6 +17,4 @@ export const useAcquireWakeLockAutomatically = () => {
       };
     }
   }, [isSupported, isVisible]);
-
-  return { isSupported };
 };

--- a/assets/src/pages/room/hooks/useMembraneClient.tsx
+++ b/assets/src/pages/room/hooks/useMembraneClient.tsx
@@ -110,7 +110,7 @@ export const useMembraneClient = (
         onTrackUpdated: (ctx: TrackContext) => {
           api.setMetadata(ctx.peer.id, ctx.trackId, ctx.metadata);
         },
-        onJoinError: (metadata) => {
+        onJoinError: (_metadata) => {
           handleError(`Failed to join the room'`);
         },
       },
@@ -135,7 +135,7 @@ export const useMembraneClient = (
         webrtc.join(peerMetadata);
         setWebrtc(webrtc);
       })
-      .receive("error", (response) => {
+      .receive("error", (_response) => {
         handleError(`Couldn't establish signaling connection`);
       });
 


### PR DESCRIPTION
In this PR:
  - the indicators that were showing as a VideoTile layer are gone;
  - the `Show Developer Info` button has been deleted;
  - wakeLock ~indicator is shown all the time, the look of it has been changed and has been located in the bottom right corner~ indicator is not visible, but the functionality is still used;
  - `MediaPlayerTileConfig` has been deprived of unused attributes