### PR TITLE
Limit the amount of peers on the server

### DIFF
--- a/.github/workflows/sandbox2_build_and_deploy.yml
+++ b/.github/workflows/sandbox2_build_and_deploy.yml
@@ -69,6 +69,7 @@ jobs:
         run: |
           echo "VIRTUAL_HOST=$VIRTUAL_HOST 
           EXTERNAL_IP=$EXTERNAL_IP 
+          MAX_PEERS=4
           TAG=$TAG 
           DB_USERNAME=$DB_USERNAME 
           DB_PASSWORD=$DB_PASSWORD

--- a/.github/workflows/sandbox3_build_deploy.yml
+++ b/.github/workflows/sandbox3_build_deploy.yml
@@ -68,6 +68,7 @@ jobs:
           GF_SECURITY_ADMIN_USER: ${{ secrets.GF_SECURITY_ADMIN_USER  }}
         run: |
           echo "VIRTUAL_HOST=$VIRTUAL_HOST 
+          MAX_PEERS=4
           EXTERNAL_IP=$EXTERNAL_IP 
           TAG=$TAG 
           DB_USERNAME=$DB_USERNAME 

--- a/.github/workflows/sandbox_build_and_deploy.yml
+++ b/.github/workflows/sandbox_build_and_deploy.yml
@@ -69,6 +69,7 @@ jobs:
         run: |
           echo "VIRTUAL_HOST=$VIRTUAL_HOST 
           EXTERNAL_IP=$EXTERNAL_IP 
+          MAX_PEERS=4
           TAG=$TAG 
           DB_USERNAME=$DB_USERNAME 
           DB_PASSWORD=$DB_PASSWORD

--- a/assets/src/pages/room/hooks/useMembraneClient.tsx
+++ b/assets/src/pages/room/hooks/useMembraneClient.tsx
@@ -144,7 +144,7 @@ export const useMembraneClient = (
       })
       .receive("error", (response) => {
         if (response === "server_full") {
-          handleError("Server is full");
+          handleError("Server has reached maximum allowed load. Disconnecting");
           cleanUp();
         } else {
           handleError(`Couldn't establish signaling connection`);

--- a/assets/src/pages/room/hooks/useMembraneClient.tsx
+++ b/assets/src/pages/room/hooks/useMembraneClient.tsx
@@ -116,6 +116,14 @@ export const useMembraneClient = (
       },
     });
 
+    const cleanUp = () => {
+      webrtc.leave();
+      webrtcChannel.leave();
+      socket.off([socketOnCloseRef, socketOnErrorRef]);
+      setWebrtc(undefined);
+    };
+
+
     webrtcChannel.on("mediaEvent", (event) => {
       webrtc.receiveMediaEvent(event.data);
     });
@@ -135,16 +143,14 @@ export const useMembraneClient = (
         webrtc.join(peerMetadata);
         setWebrtc(webrtc);
       })
-      .receive("error", (_response) => {
-        handleError(`Couldn't establish signaling connection`);
+      .receive("error", (response) => {
+        if(response === "server_full") {
+          handleError("Server is full")
+          cleanUp()
+        } else {
+          handleError(`Couldn't establish signaling connection`);
+        }
       });
-
-    const cleanUp = () => {
-      webrtc.leave();
-      webrtcChannel.leave();
-      socket.off([socketOnCloseRef, socketOnErrorRef]);
-      setWebrtc(undefined);
-    };
 
     return () => {
       cleanUp();

--- a/assets/src/pages/room/hooks/useMembraneClient.tsx
+++ b/assets/src/pages/room/hooks/useMembraneClient.tsx
@@ -123,7 +123,6 @@ export const useMembraneClient = (
       setWebrtc(undefined);
     };
 
-
     webrtcChannel.on("mediaEvent", (event) => {
       webrtc.receiveMediaEvent(event.data);
     });
@@ -144,9 +143,9 @@ export const useMembraneClient = (
         setWebrtc(webrtc);
       })
       .receive("error", (response) => {
-        if(response === "server_full") {
-          handleError("Server is full")
-          cleanUp()
+        if (response === "server_full") {
+          handleError("Server is full");
+          cleanUp();
         } else {
           handleError(`Couldn't establish signaling connection`);
         }

--- a/config/config.exs
+++ b/config/config.exs
@@ -13,9 +13,7 @@ config :esbuild,
 
 config :membrane_videoroom_demo, VideoRoomWeb.Endpoint, pubsub_server: VideoRoom.PubSub
 
-config :membrane_videoroom_demo,
-  version: System.get_env("VERSION", "unknown"),
-  max_peers: "MAX_PEERS" |> System.get_env("5") |> String.to_integer()
+config :membrane_videoroom_demo, version: System.get_env("VERSION", "unknown")
 
 config :logger,
   compile_time_purge_matching: [

--- a/config/config.exs
+++ b/config/config.exs
@@ -13,7 +13,9 @@ config :esbuild,
 
 config :membrane_videoroom_demo, VideoRoomWeb.Endpoint, pubsub_server: VideoRoom.PubSub
 
-config :membrane_videoroom_demo, version: System.get_env("VERSION", "unknown")
+config :membrane_videoroom_demo,
+  version: System.get_env("VERSION", "unknown"),
+  max_peers: "MAX_PEERS" |> System.get_env("5") |> String.to_integer()
 
 config :logger,
   compile_time_purge_matching: [

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -62,6 +62,7 @@ defmodule ConfigParser do
 end
 
 config :membrane_videoroom_demo,
+  max_peers: "MAX_PEERS" |> System.get_env("5") |> String.to_integer(),
   integrated_turn_ip:
     System.get_env("EXTERNAL_IP", "127.0.0.1") |> ConfigParser.parse_integrated_turn_ip(),
   integrated_turn_port_range:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       INTEGRATED_TCP_TURN_PORT: "49999"
       STORE_METRICS: "true"
       DATABASE: "membrane"
+      MAX_PEERS: "${MAX_PEERS}"
       DB_USERNAME: "${DB_USERNAME}"
       DB_PASSWORD: "${DB_PASSWORD}"
       DB_HOSTNAME: "127.0.0.1"

--- a/lib/videoroom/application.ex
+++ b/lib/videoroom/application.ex
@@ -20,7 +20,8 @@ defmodule VideoRoom.Application do
         VideoRoomWeb.Endpoint,
         {Phoenix.PubSub, name: VideoRoom.PubSub},
         {Registry, keys: :unique, name: Videoroom.Room.Registry},
-        {DynamicSupervisor, strategy: :one_for_one, name: Videoroom.RoomMonitorSupervisor}
+        {DynamicSupervisor, strategy: :one_for_one, name: Videoroom.RoomMonitorSupervisor},
+        Videoroom.PeersTracker
       ] ++
         if store_metrics do
           Application.ensure_all_started(:membrane_rtc_engine_timescaledb)

--- a/lib/videoroom/peers_tracker.ex
+++ b/lib/videoroom/peers_tracker.ex
@@ -1,0 +1,58 @@
+defmodule Videoroom.PeersTracker do
+  @moduledoc false
+
+  # Module responsible for ensuring that we won't allow more peers than the server can handle
+  # It is crutial to ensure that we don't get random timeouts and other overload problems
+
+  use Agent
+
+  @type peer_id() :: Membrane.RTC.Engine.Endpoint.id()
+
+  defmodule State do
+    @moduledoc false
+
+    @enforce_keys [:max_peers]
+    defstruct @enforce_keys ++ [peers: MapSet.new()]
+  end
+
+  @spec start_link([]) :: Agent.on_start()
+  def start_link([]) do
+    Agent.start_link(
+      fn -> %State{max_peers: Application.fetch_env!(:membrane_videoroom_demo, :max_peers)} end,
+      name: __MODULE__
+    )
+  end
+
+  @spec try_add(peer_id()) :: :ok | {:error, :full}
+  def try_add(pid) do
+    internal_pid = {self(), pid}
+
+    Agent.get_and_update(__MODULE__, fn state ->
+      if Enum.count(state.peers) == state.max_peers do 
+        {{:error, :full}, state}
+      else
+        {:ok, %{state | peers: MapSet.put(state.peers, internal_pid)}}
+      end
+    end)
+  end
+
+  @spec remove(peer_id()) :: :ok
+  def remove(pid) do
+    internal_pid = {self(), pid}
+    Agent.update(__MODULE__, &%{&1 | peers: MapSet.delete(&1.peers, internal_pid)})
+  end
+
+  @spec remove_all() :: :ok
+  def remove_all() do
+    pid = self()
+
+    Agent.update(__MODULE__, fn state ->
+      peers =
+        state.peers
+        |> Enum.reject(&match?({^pid, _peer_id}, &1))
+        |> MapSet.new()
+
+      %{state | peers: peers}
+    end)
+  end
+end

--- a/lib/videoroom/peers_tracker.ex
+++ b/lib/videoroom/peers_tracker.ex
@@ -4,55 +4,25 @@ defmodule Videoroom.PeersTracker do
   # Module responsible for ensuring that we won't allow more peers than the server can handle
   # It is crutial to ensure that we don't get random timeouts and other overload problems
 
-  use Agent
-
   @type peer_id() :: Membrane.RTC.Engine.Endpoint.id()
 
-  defmodule State do
-    @moduledoc false
-
-    @enforce_keys [:max_peers]
-    defstruct @enforce_keys ++ [peers: MapSet.new()]
-  end
-
-  @spec start_link([]) :: Agent.on_start()
-  def start_link([]) do
-    Agent.start_link(
-      fn -> %State{max_peers: Application.fetch_env!(:membrane_videoroom_demo, :max_peers)} end,
-      name: __MODULE__
-    )
+  @spec child_spec([]) :: Supervisor.child_spec()
+  def child_spec([]) do
+    Registry.child_spec(name: __MODULE__, keys: :unique)
   end
 
   @spec try_add(peer_id()) :: :ok | {:error, :full}
-  def try_add(pid) do
-    internal_pid = {self(), pid}
-
-    Agent.get_and_update(__MODULE__, fn state ->
-      if Enum.count(state.peers) == state.max_peers do
-        {{:error, :full}, state}
-      else
-        {:ok, %{state | peers: MapSet.put(state.peers, internal_pid)}}
-      end
-    end)
+  def try_add(peer_id) do
+    if Registry.count(__MODULE__) == Application.fetch_env!(:membrane_videoroom_demo, :max_peers) do
+      {:error, :full}
+    else
+      Registry.register(__MODULE__, peer_id, nil)
+      :ok
+    end
   end
 
   @spec remove(peer_id()) :: :ok
-  def remove(pid) do
-    internal_pid = {self(), pid}
-    Agent.update(__MODULE__, &%{&1 | peers: MapSet.delete(&1.peers, internal_pid)})
-  end
-
-  @spec remove_all() :: :ok
-  def remove_all() do
-    pid = self()
-
-    Agent.update(__MODULE__, fn state ->
-      peers =
-        state.peers
-        |> Enum.reject(&match?({^pid, _peer_id}, &1))
-        |> MapSet.new()
-
-      %{state | peers: peers}
-    end)
+  def remove(peer_id) do
+    Registry.unregister(__MODULE__, peer_id)
   end
 end

--- a/lib/videoroom/peers_tracker.ex
+++ b/lib/videoroom/peers_tracker.ex
@@ -28,7 +28,7 @@ defmodule Videoroom.PeersTracker do
     internal_pid = {self(), pid}
 
     Agent.get_and_update(__MODULE__, fn state ->
-      if Enum.count(state.peers) == state.max_peers do 
+      if Enum.count(state.peers) == state.max_peers do
         {{:error, :full}, state}
       else
         {:ok, %{state | peers: MapSet.put(state.peers, internal_pid)}}

--- a/lib/videoroom/peers_tracker.ex
+++ b/lib/videoroom/peers_tracker.ex
@@ -14,7 +14,7 @@ defmodule Videoroom.PeersTracker do
   @spec try_add(peer_id()) :: :ok | {:error, :full}
   def try_add(peer_id) do
     if Registry.count(__MODULE__) == Application.fetch_env!(:membrane_videoroom_demo, :max_peers) do
-      {:error, :full}
+      {:error, :server_full}
     else
       Registry.register(__MODULE__, peer_id, nil)
       :ok

--- a/lib/videoroom/room.ex
+++ b/lib/videoroom/room.ex
@@ -223,6 +223,7 @@ defmodule Videoroom.Room do
       case Engine.terminate(state.rtc_engine, blocking?: true) do
         :ok ->
           Membrane.Logger.info("Engine terminated.")
+          {:stop, :normal, state}
 
         error ->
           Membrane.Logger.error(
@@ -230,10 +231,8 @@ defmodule Videoroom.Room do
           )
 
           Process.exit(state.rtc_engine, :kill)
+          {:noreply, state}
       end
-
-      PeersTracker.remove_all()
-      {:stop, :normal, state}
     else
       {:noreply, state}
     end

--- a/lib/videoroom_web/peer_channel.ex
+++ b/lib/videoroom_web/peer_channel.ex
@@ -98,6 +98,9 @@ defmodule VideoRoomWeb.PeerChannel do
 
         {:ok,
          Phoenix.Socket.assign(socket, %{room_id: room_id, room_pid: room_pid, peer_id: peer_id})}
+
+      {:error, :full} ->
+        {:error, :server_full}
     end
   end
 end

--- a/lib/videoroom_web/peer_channel.ex
+++ b/lib/videoroom_web/peer_channel.ex
@@ -99,7 +99,7 @@ defmodule VideoRoomWeb.PeerChannel do
         {:ok,
          Phoenix.Socket.assign(socket, %{room_id: room_id, room_pid: room_pid, peer_id: peer_id})}
 
-      {:error, :full} ->
+      {:error, :server_full} ->
         {:error, :server_full}
     end
   end


### PR DESCRIPTION
- Limit the amount of peers on the server
- Limit the amount of peers on sandboxes to 4
- Pass variable through docker-compose.yml
