### PR TITLE
MV-302 Change the display of an error reason

### DIFF
--- a/assets/src/pages/room/hooks/useMembraneClient.tsx
+++ b/assets/src/pages/room/hooks/useMembraneClient.tsx
@@ -47,7 +47,8 @@ export const useMembraneClient = (
     });
 
     webrtcChannel.onError((reason) => {
-      handleError(`Webrtc channel error occurred. ${reason ?? ""}`);
+      console.error(reason);
+      handleError(`Webrtc channel error occurred. Check browser logs for more details.`);
     });
     webrtcChannel.onClose(() => {
       return;


### PR DESCRIPTION
Reason is no longer shown in the error message and is displayed in the `stderr`.