### PR TITLE
fix empty gap

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -39,15 +39,6 @@
   min-height: 70px;
 }
 
-/**
-Don't display screensharing control on mobile browsers
-**/
-@media (max-width: 768px) {
-  .screensharing-control {
-    display: none;
-  }
-}
-
 .grid-wrapper {
   --navbar: 48px;
   --menuTooltip: 42px;

--- a/assets/src/pages/room/components/MediaControlButton.tsx
+++ b/assets/src/pages/room/components/MediaControlButton.tsx
@@ -3,6 +3,7 @@ import React, { FC, SVGAttributes } from "react";
 import Button from "../../../features/shared/components/Button";
 
 export type MediaControlButtonProps = {
+  id: string;
   onClick: () => void;
   hover: string;
   className?: string;
@@ -10,13 +11,15 @@ export type MediaControlButtonProps = {
 };
 
 const MediaControlButton: FC<MediaControlButtonProps> = ({
+  id,
   hover,
   icon: Icon,
   onClick,
   className,
 }: MediaControlButtonProps) => {
+  const isScreenshareButton = id == "screenshare-start" || id == "screenshare-stop";
   return (
-    <div className="group relative">
+    <div className={clsx("group relative", isScreenshareButton && "screensharing-control")}>
       <Button
         onClick={onClick}
         className={clsx(

--- a/assets/src/pages/room/components/MediaControlButton.tsx
+++ b/assets/src/pages/room/components/MediaControlButton.tsx
@@ -7,19 +7,19 @@ export type MediaControlButtonProps = {
   onClick: () => void;
   hover: string;
   className?: string;
+  hideOnMobile?: boolean;
   icon: React.FC<SVGAttributes<SVGElement>>;
 };
 
 const MediaControlButton: FC<MediaControlButtonProps> = ({
-  id,
   hover,
   icon: Icon,
   onClick,
+  hideOnMobile,
   className,
 }: MediaControlButtonProps) => {
-  const isScreenshareButton = id == "screenshare-start" || id == "screenshare-stop";
   return (
-    <div className={clsx("group relative", isScreenshareButton && "screensharing-control")}>
+    <div className={clsx("group relative", hideOnMobile && "hidden md:inline-block")}>
       <Button
         onClick={onClick}
         className={clsx(

--- a/assets/src/pages/room/components/MediaControlButton.tsx
+++ b/assets/src/pages/room/components/MediaControlButton.tsx
@@ -3,7 +3,6 @@ import React, { FC, SVGAttributes } from "react";
 import Button from "../../../features/shared/components/Button";
 
 export type MediaControlButtonProps = {
-  id: string;
   onClick: () => void;
   hover: string;
   className?: string;

--- a/assets/src/pages/room/components/MediaControlButtons.tsx
+++ b/assets/src/pages/room/components/MediaControlButtons.tsx
@@ -88,6 +88,7 @@ const getAutomaticControls = (
         icon: Screenshare,
         hover: "Stop sharing your screen",
         className: neutralButtonStyle,
+        hideOnMobile: true,
         onClick: () => {
           displayMedia.stop();
           screenSharingStreaming.setActive(false);
@@ -98,6 +99,7 @@ const getAutomaticControls = (
         icon: Screenshare,
         hover: "Share your screen",
         className: neutralButtonStyle,
+        hideOnMobile: true,
         onClick: () => {
           displayMedia.start();
           screenSharingStreaming.setActive(true);
@@ -266,6 +268,7 @@ const getManualControls = (
           icon: Screenshare,
           className: neutralButtonStyle,
           hover: "Stop the screensharing",
+          hideOnMobile: true,
           onClick: () => displayMedia.stop(),
         }
       : {
@@ -273,6 +276,7 @@ const getManualControls = (
           icon: Screenshare,
           className: neutralButtonStyle,
           hover: "Start the screensharing",
+          hideOnMobile: true,
           onClick: () => displayMedia.start(),
         },
     displayMedia.isEnabled
@@ -281,6 +285,7 @@ const getManualControls = (
           icon: Screenshare,
           className: neutralButtonStyle,
           hover: "Disable screensharing stream",
+          hideOnMobile: true,
           onClick: () => displayMedia.disable(),
         }
       : {
@@ -288,6 +293,7 @@ const getManualControls = (
           icon: Screenshare,
           className: neutralButtonStyle,
           hover: "Enable screensharing stream",
+          hideOnMobile: true,
           onClick: () => displayMedia.enable(),
         },
     screenSharingStreaming.trackId
@@ -296,6 +302,7 @@ const getManualControls = (
           icon: Screenshare,
           className: neutralButtonStyle,
           hover: "Remove screensharing track",
+          hideOnMobile: true,
           onClick: () => screenSharingStreaming.removeTracks(),
         }
       : {
@@ -303,6 +310,7 @@ const getManualControls = (
           icon: Screenshare,
           className: neutralButtonStyle,
           hover: "Add screensharing track",
+          hideOnMobile: true,
           onClick: () => displayMedia?.stream && screenSharingStreaming.addTracks(displayMedia?.stream),
         },
     screenSharingStreaming.trackMetadata?.active
@@ -311,6 +319,7 @@ const getManualControls = (
           icon: Screenshare,
           className: neutralButtonStyle,
           hover: "Set 'active' metadata to 'false'",
+          hideOnMobile: true,
           onClick: () => screenSharingStreaming.setActive(false),
         }
       : {
@@ -318,6 +327,7 @@ const getManualControls = (
           icon: Screenshare,
           className: neutralButtonStyle,
           hover: "Set 'active' metadata to 'true'",
+          hideOnMobile: true,
           onClick: () => screenSharingStreaming.setActive(true),
         },
   ],
@@ -364,7 +374,7 @@ const MediaControlButtons: FC<Props> = (props: Props) => {
         <div className="inset-x-0 z-10 flex flex-wrap justify-center gap-x-4 rounded-t-md">
           {controls.map((group, index) => (
             <div key={index} className="flex justify-center gap-x-4">
-              {group.map(({ hover, onClick, className, id, icon }) => (
+              {group.map(({ hover, onClick, className, id, icon, hideOnMobile }) => (
                 <MediaControlButton
                   key={id}
                   id={id}
@@ -372,6 +382,7 @@ const MediaControlButtons: FC<Props> = (props: Props) => {
                   hover={hover}
                   className={className}
                   icon={icon}
+                  hideOnMobile={hideOnMobile}
                 />
               ))}
             </div>

--- a/assets/src/pages/room/components/MediaControlButtons.tsx
+++ b/assets/src/pages/room/components/MediaControlButtons.tsx
@@ -11,11 +11,10 @@ import Camera from "../../../features/room-page/icons/Camera";
 import CameraOff from "../../../features/room-page/icons/CameraOff";
 import Screenshare from "../../../features/room-page/icons/Screenshare";
 import HangUp from "../../../features/room-page/icons/HangUp";
-import clsx from "clsx";
 import useToast from "../../../features/shared/hooks/useToast";
 import { ToastType } from "../../../features/shared/context/ToastContext";
 
-type ControlButton = MediaControlButtonProps & { id: string };
+type ControlButton = MediaControlButtonProps;
 
 const neutralButtonStyle = "border-brand-dark-blue-400 text-brand-dark-blue-500 bg-white";
 const activeButtonStyle = "text-brand-white bg-brand-dark-blue-400 border-brand-dark-blue-400";
@@ -85,20 +84,20 @@ const getAutomaticControls = (
       },
   displayMedia.stream
     ? {
-        id: "stream-stop",
+        id: "screenshare-stop",
         icon: Screenshare,
         hover: "Stop sharing your screen",
-        className: clsx(neutralButtonStyle, "screensharing-control"),
+        className: neutralButtonStyle,
         onClick: () => {
           displayMedia.stop();
           screenSharingStreaming.setActive(false);
         },
       }
     : {
-        id: "stream-start",
+        id: "screenshare-start",
         icon: Screenshare,
         hover: "Share your screen",
-        className: clsx(neutralButtonStyle, "screensharing-control"),
+        className: neutralButtonStyle,
         onClick: () => {
           displayMedia.start();
           screenSharingStreaming.setActive(true);
@@ -366,7 +365,14 @@ const MediaControlButtons: FC<Props> = (props: Props) => {
           {controls.map((group, index) => (
             <div key={index} className="flex justify-center gap-x-4">
               {group.map(({ hover, onClick, className, id, icon }) => (
-                <MediaControlButton key={id} onClick={onClick} hover={hover} className={className} icon={icon} />
+                <MediaControlButton
+                  key={id}
+                  id={id}
+                  onClick={onClick}
+                  hover={hover}
+                  className={className}
+                  icon={icon}
+                />
               ))}
             </div>
           ))}

--- a/assets/src/pages/room/components/MediaControlButtons.tsx
+++ b/assets/src/pages/room/components/MediaControlButtons.tsx
@@ -14,7 +14,7 @@ import HangUp from "../../../features/room-page/icons/HangUp";
 import useToast from "../../../features/shared/hooks/useToast";
 import { ToastType } from "../../../features/shared/context/ToastContext";
 
-type ControlButton = MediaControlButtonProps;
+type ControlButton = MediaControlButtonProps & { id: string };
 
 const neutralButtonStyle = "border-brand-dark-blue-400 text-brand-dark-blue-500 bg-white";
 const activeButtonStyle = "text-brand-white bg-brand-dark-blue-400 border-brand-dark-blue-400";
@@ -377,7 +377,6 @@ const MediaControlButtons: FC<Props> = (props: Props) => {
               {group.map(({ hover, onClick, className, id, icon, hideOnMobile }) => (
                 <MediaControlButton
                   key={id}
-                  id={id}
                   onClick={onClick}
                   hover={hover}
                   className={className}


### PR DESCRIPTION
It fixes an empty gap when screenshare button is hidden on mobile
<img width="311" alt="image" src="https://user-images.githubusercontent.com/56414498/218753453-c386b8d8-a84e-46c6-8f9e-95f9b5d385ae.png">
