### PR TITLE
Rename `Show simulcast controls` to `Nerd options`

### DIFF
--- a/assets/src/pages/room/RoomPage.tsx
+++ b/assets/src/pages/room/RoomPage.tsx
@@ -115,7 +115,7 @@ const RoomPage: FC<Props> = ({ roomId, displayName, isSimulcastOn, manualMode, a
               className="focus:outline-none focus:shadow-outline m-1 w-full rounded bg-brand-grey-80 py-2 px-4 text-white hover:bg-brand-grey-100"
               type="submit"
             >
-              Show simulcast controls
+              Nerd options
             </button>
           )}
         </div>


### PR DESCRIPTION
I believe this is how the button should be really named