### PR TITLE
Update esbuild and configs to match phx.new template

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -3,10 +3,10 @@ import Config
 config :phoenix, :json_library, Jason
 
 config :esbuild,
-  version: "0.12.15",
+  version: "0.14.29",
   default: [
     args:
-      ~w(src/index.tsx --bundle --target=es2016 --outfile=../priv/static/assets/js/app.js --external:/images/*),
+      ~w(src/index.tsx --bundle --target=es2017 --outfile=../priv/static/assets/js/app.js --external:/images/*),
     cd: Path.expand("../assets", __DIR__),
     env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
   ]

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,14 +1,11 @@
 import Config
 
 config :membrane_videoroom_demo, VideoRoomWeb.Endpoint,
+  check_origin: false,
   code_reloader: true,
+  debug_errors: true,
   watchers: [
-    esbuild:
-      {Esbuild, :install_and_run,
-       [
-         :default,
-         ~w(--sourcemap=inline --bundle --watch)
-       ]},
+    esbuild: {Esbuild, :install_and_run, [:default, ~w(--sourcemap=inline --watch)]},
     npx: [
       "tailwindcss",
       "--input=css/app.css",
@@ -30,3 +27,9 @@ config :membrane_videoroom_demo, VideoRoomWeb.Endpoint,
   ]
 
 config :logger, level: :info
+
+# Set a higher stacktrace during development. Avoid configuring such
+# in production as building large stacktraces may be expensive.
+config :phoenix, :stacktrace_depth, 20
+# Initialize plugs at runtime for faster development compilation
+config :phoenix, :plug_init_mode, :runtime

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,1 +1,4 @@
 import Config
+
+# Initialize plugs at runtime for faster test compilation
+config :phoenix, :plug_init_mode, :runtime


### PR DESCRIPTION
The main reason for the upgrade was the introduction of `check_origin: false` option present in the template. Along the way, I've added other options present in the template - including eslint update