### PR TITLE
fix/dynamic-viewport

### DIFF
--- a/assets/src/features/home-page/components/HomePageLayout.tsx
+++ b/assets/src/features/home-page/components/HomePageLayout.tsx
@@ -7,7 +7,7 @@ const HomePageLayout: React.FC<PropsWithChildren> = ({ children }) => {
   return (
     <div
       className={clsx(
-        "home-page h-[100dvh] w-full bg-brand-sea-blue-200 text-brand-dark-blue-500",
+        "home-page h-screen w-full bg-brand-sea-blue-200 text-brand-dark-blue-500",
         "font-rocGrotesk",
         "flex flex-col items-center gap-y-4 p-4",
         "relative overflow-y-auto"

--- a/assets/src/features/room-page/components/PageLayout.tsx
+++ b/assets/src/features/room-page/components/PageLayout.tsx
@@ -6,7 +6,7 @@ const PageLayout: React.FC<PropsWithChildren> = ({ children }) => {
   return (
     <div
       className={clsx(
-        "h-[100dvh] w-full",
+        "h-screen w-full",
         "bg-brand-sea-blue-100 font-rocGrotesk text-brand-dark-blue-500",
         "flex flex-col items-center gap-y-4 p-4"
       )}


### PR DESCRIPTION
Replace the dynamic viewport with the normal one, since ~70% support for this feature is insufficient for our usage.
As a result, it will cause an imperfect layout on some mobile devices since mobile browser headers are not included in the basic viewport. I'll create a ticket for implementing a new solution for this use case. 