### PR TITLE
Fix of horizontal block problems

### DIFF
--- a/assets/src/features/shared/hooks/useSmartphoneViewport.tsx
+++ b/assets/src/features/shared/hooks/useSmartphoneViewport.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { MOBILE_WIDTH_BREAKPOINT, MAX_MOBILE_WIDTH_BREAKPOINT } from "../consts";
 
 type ScreenInfo = {
@@ -10,14 +10,18 @@ const useSmartphoneViewport = (): ScreenInfo => {
   const [isSmartphone, setIsSmartphone] = useState<boolean | undefined>();
   const [isHorizontal, setIsHorizontal] = useState<boolean | undefined>();
 
+  const isLandscape = useCallback(() => {
+    if (typeof window === "undefined") return;
+
+    return screen.orientation?.type.includes("landscape") || window.matchMedia("(orientation: landscape)").matches;
+  }, []);
+
   useEffect(() => {
     if (typeof window !== "undefined") {
       // The screen.orientation.type is widely available on most of the devices but it was recently added to mobile safari.
       // Source: https://developer.mozilla.org/en-US/docs/Web/API/Screen/orientation
       // At the day of writing this comment (May 8th 2023) some web apps like Chrome on iOS does NOT implement this.
       // The `windows.matchMedia` is used as a fallback for such devices.
-      const isLandscape =
-        screen.orientation?.type.includes("landscape") || window.matchMedia("(orientation: landscape)").matches;
 
       const updateIsSmartphoneState = () => {
         if (!window.visualViewport) return;
@@ -25,14 +29,14 @@ const useSmartphoneViewport = (): ScreenInfo => {
         const isCoarse = matchMedia("(pointer:coarse)").matches;
         const hasMobileWidth = window.visualViewport.width <= MOBILE_WIDTH_BREAKPOINT;
 
-        const isLandscapedSmartphone = isLandscape && window.visualViewport.width <= MAX_MOBILE_WIDTH_BREAKPOINT; // iPhone 12 max  viewpor width
+        const isLandscapedSmartphone = isLandscape() && window.visualViewport.width <= MAX_MOBILE_WIDTH_BREAKPOINT; // iPhone 12 max  viewpor width
         setIsSmartphone(isCoarse && (hasMobileWidth || isLandscapedSmartphone));
       };
 
       const updateIsHorizontalOrientationState = () => {
         if (!screen) return;
 
-        setIsHorizontal(isLandscape);
+        setIsHorizontal(isLandscape());
       };
 
       const updateState = () => {
@@ -42,9 +46,13 @@ const useSmartphoneViewport = (): ScreenInfo => {
 
       updateState();
       window.addEventListener("resize", updateState);
-      return () => window.removeEventListener("resize", updateState);
+      if (screen.orientation) screen.orientation.addEventListener("change", updateState); //Safari does NOT consider orientation change to be a resize so this event listener is needed.
+      return () => {
+        window.removeEventListener("resize", updateState);
+        if (screen.orientation) screen.orientation.removeEventListener("change", updateState);
+      };
     }
-  }, []);
+  }, [isLandscape]);
 
   return { isSmartphone, isHorizontal };
 };


### PR DESCRIPTION
Fix of lack of blocking screen on mobile devices.

Both iOS and Android phones had lacked the block on horizontal screen causing the layout to break. This fix tries to address some issues found with detecting if the user phone is in horizontal mode.