### PR TITLE
Update benchmarks

### DIFF
--- a/assets/src/features/home-page/components/VideoroomHomePage.tsx
+++ b/assets/src/features/home-page/components/VideoroomHomePage.tsx
@@ -173,7 +173,7 @@ const VideoroomHomePage: React.FC = () => {
 
         <div className="flex w-full flex-col items-center justify-center gap-x-12 sm:max-h-[400px] sm:flex-row lg:gap-x-24">
           {/* mobile view */}
-          <div className="flex w-full flex-col items-center gap-y-6 sm:hidden">
+          <div id="mobile_home_form" className="flex w-full flex-col items-center gap-y-6 sm:hidden">
             {mobileLoginSteps[mobileCurrentLoginStep].content}
             {mobileLoginSteps[mobileCurrentLoginStep].button}
             {!joiningExistingRoom && (
@@ -190,7 +190,7 @@ const VideoroomHomePage: React.FC = () => {
               <HomePageVideoTile displayName={displayNameInput} />
             </div>
 
-            <div className="hidden w-auto flex-col items-center justify-center gap-y-6 sm:flex">
+            <div id="desktop_home_form" className="hidden w-auto flex-col items-center justify-center gap-y-6 sm:flex">
               {inputs}
               <div className="space-y-1">
                 {checkboxes.map(({ label, id, status, onChange }) => (

--- a/benchmarks/multiroom.exs
+++ b/benchmarks/multiroom.exs
@@ -9,7 +9,7 @@ defmodule MultiroomScenario do
   @peer_delay 1_000
   # in miliseconds
   @peer_duration 120_000
-  @url "http://localhost:4000/?room_id=benchmark"
+  @url "http://localhost:4000/room/benchmark"
 
   @impl true
   def run() do

--- a/benchmarks/simple.exs
+++ b/benchmarks/simple.exs
@@ -8,7 +8,7 @@ defmodule SimpleScenario do
   @peer_delay 1_000
   # in miliseconds
   @peer_duration 120_000
-  @room_url "http://localhost:4000/?room_id=benchmark"
+  @room_url "http://localhost:4000/room/benchmark"
 
   # stampede or chrome cannot connect more than 16 peers using one instance of browser
   # the problem is probably with granting permissions to mic/cam

--- a/benchmarks/simple_mustang.ex
+++ b/benchmarks/simple_mustang.ex
@@ -6,8 +6,8 @@ defmodule SimpleMustang do
     page = browser |> Playwright.Browser.new_page()
     _response = Playwright.Page.goto(page, options.target_url)
 
-    :ok = Playwright.Page.fill(page, "[name=display_name]", "stampede")
-    :ok = Playwright.Page.click(page, "[type=submit]")
+    :ok = Playwright.Page.fill(page,  "(//input[@id=\"display_name\"])[2]", "stampede")
+    :ok = Playwright.Page.click(page, "#join")
 
     {browser, page}
   end

--- a/benchmarks/simple_mustang.ex
+++ b/benchmarks/simple_mustang.ex
@@ -6,7 +6,7 @@ defmodule SimpleMustang do
     page = browser |> Playwright.Browser.new_page()
     _response = Playwright.Page.goto(page, options.target_url)
 
-    :ok = Playwright.Page.fill(page,  "(//input[@id=\"display_name\"])[2]", "stampede")
+    :ok = Playwright.Page.fill(page,  "#desktop_home_form [name=display_name]", "stampede")
     :ok = Playwright.Page.click(page, "#join")
 
     {browser, page}


### PR DESCRIPTION
Some div IDs/names were changed and joining room via link is not using GET parameter anymore

Changes:
1. Update test URL - room name is now part of path instead of `room_id` GET parameter
2. Update selectors
   1. Display name input occurs twice in the UI currently (although it's not displayed twice), now it's using xpath selector for the 2nd one
   2. There's no submit type element, using join link